### PR TITLE
Prevent undefined dereference in TokenMatcher::compare

### DIFF
--- a/lib/TokenMatcher.coffee
+++ b/lib/TokenMatcher.coffee
@@ -21,7 +21,10 @@ class TokenMatcher
   @compare: ( tokens1, tokens2 ) ->
 
     score = 0
-    tokens1.map (t) -> score++ if tokens2.indexOf( t ) > -1
+
+    if tokens2
+      tokens1.map (t) -> score++ if tokens2.indexOf( t ) > -1
+
     return score
 
 module.exports = TokenMatcher


### PR DESCRIPTION
This relates to issue https://github.com/missinglink/breakdown/issues/2.

I did try to have a dig around and investigate the root cause but my skillz were not skillful enough, sorry. Anyway, this change prevents breakdown from chucking a fit in my case and lets me see the original error message.
